### PR TITLE
Ignore camel case serialization for dictionary keys

### DIFF
--- a/Source/JSInterop.cs
+++ b/Source/JSInterop.cs
@@ -39,6 +39,13 @@ namespace DotNetify.Blazor
       {
          ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
          ContractResolver = new CamelCasePropertyNamesContractResolver()
+         {
+            NamingStrategy = new CamelCaseNamingStrategy()
+            {
+               ProcessDictionaryKeys = false,
+               OverrideSpecifiedNames = true
+            }
+         }
       };
 
       public JSInterop(IJSRuntime jsRuntime)


### PR DESCRIPTION
Fixes #7 by ignoring dictionary keys when serializing the VMConnectOptions.