### PR TITLE
fix: JsonSerializationException: A member with the name '' already exists on VMConnectOptions

### DIFF
--- a/Source/VMConnectOptions.cs
+++ b/Source/VMConnectOptions.cs
@@ -16,6 +16,7 @@ limitations under the License.
 
 using System;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace DotNetify.Blazor
 {
@@ -42,6 +43,7 @@ namespace DotNetify.Blazor
       /// <summary>
       /// Callback when getting exception from server-side view model.
       /// </summary>
+      [JsonIgnore]
       public Action<ExceptionEventArgs> ExceptionHandler { get; set; }
    }
 }


### PR DESCRIPTION
fix: JsonSerializationException: A member with the name '' already exists on VMConnectOptions

The ExceptionHandler property in the VMConnectOptions class was causing a serialization error with the message: "Unhandled exception rendering component: A member with the name '' already exists on 'System.Action`1[DotNetify.Blazor.ExceptionEventArgs]'. Use the JsonPropertyAttribute to specify another name."

Action<T> delegates are not serializable by default, leading to this issue. Added [JsonIgnore] attribute to exclude the ExceptionHandler property from serialization to resolve the problem.